### PR TITLE
fix for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ By default, aiac prints the extracted code to standard output and asks if it sho
 
 To store the resulting code to a file:
 
-    aiac -o="aws_ec2.tf" get terraform for AWS EC2
+    aiac -o "aws_ec2.tf" get terraform for AWS EC2
          
 To run using `docker`
 


### PR DESCRIPTION
Hi, I've noticed that outputing with ```=``` creates a filename with ```=```. Fix in documentation in PR.