### PR TITLE
fix: fprintf error

### DIFF
--- a/libaiac/libaiac.go
+++ b/libaiac/libaiac.go
@@ -135,7 +135,7 @@ func (client *Client) Ask(
 	spin.Stop()
 	killed = true
 
-	fmt.Fprintf(os.Stdout, code)
+	fmt.Fprint(os.Stdout, code)
 	if shouldQuit {
 		return nil
 	}


### PR DESCRIPTION
Thanks for your great work! It's very useful for developers like me. However I noticed a print error. It's not hard to fix, hope this pull request would be helpful

# description

change `Fprintf`to `Fprint`

# How Has This Been Tested?
The second parameter of `fmt.Fprintf` is 'format', therefore when there are something like "%s" in code, the print would be "%!s(MISSING)", just as shown below
```
func Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
	p := newPrinter()
	p.doPrintf(format, a)
	n, err = w.Write(p.buf)
	p.free()
	return
}
```

<img width="707" alt="image" src="https://user-images.githubusercontent.com/99850403/217273211-a9d31fe8-a664-4991-a3d6-eb0bf0ebc447.png">


`fmt.Fprint` doesn't have parameter 'format', so the print will always be correct
```
func Fprint(w io.Writer, a ...any) (n int, err error) {
	p := newPrinter()
	p.doPrint(a)
	n, err = w.Write(p.buf)
	p.free()
	return
}
```
<img width="705" alt="image" src="https://user-images.githubusercontent.com/99850403/217273701-3eb2f83c-2d51-4939-84f1-c52de529e0f3.png">