### PR TITLE
Remove ChatGPT support, document code, small refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ Generator.
 <!-- vim-markdown-toc GFM -->
 
 * [Description](#description)
-* [Use Cases](#use-cases-and-example-prompts)
+* [Use Cases and Example Prompts](#use-cases-and-example-prompts)
+    * [Generate IaC](#generate-iac)
+    * [Generate Configuration Files](#generate-configuration-files)
+    * [Generate CICD Pipelines](#generate-cicd-pipelines)
+    * [Generate Policy as Code](#generate-policy-as-code)
+    * [Generate Utilities](#generate-utilities)
+    * [Command Line Builder](#command-line-builder)
+    * [Query Builder](#query-builder)
 * [Quick Start](#quick-start)
+    * [Instructions](#instructions)
 * [Example Output](#example-output)
 * [Support Channels](#support-channels)
 * [License](#license)
@@ -28,35 +36,40 @@ output.
 ## Use Cases and Example Prompts
 
 ### Generate IaC
+
 - `aiac get terraform for a highly available eks`
 - `aiac get pulumi golang for an s3 with sns notification`
 - `aiac get cloudformation for a neptundb`
 
 ### Generate Configuration Files
+
 - `aiac get dockerfile for a secured nginx`
 - `aiac get k8s manifest for a mongodb deployment`
 
 ### Generate CICD Pipelines
+
 - `aiac get jenkins pipeline for building nodejs`
 - `aiac get github action that plans and applies terraform and sends a slack notification`
 
 ### Generate Policy as Code
+
 - `aiac get opa policy that enforces readiness probe at k8s deployments`
 
 ### Generate Utilities
+
 - `aiac get python code that scans all open ports in my network`
 - `aiac get bash script that kills all active terminal sessions`
 
 ### Command Line Builder
+
 - `aiac get kubectl that gets ExternalIPs of all nodes`
 - `aiac get awscli that lists instances with public IP address and Name`
 
 ### Query Builder
+
 - `aiac get mongo query that aggregates all documents by created date`
 - `aiac get elastic query that applies a condition on a value greater than some value in aggregation`
 - `aiac get sql query that counts the appearances of each row in one table in another table based on an id column`
-
-
 
 ## Quick Start
 
@@ -68,11 +81,14 @@ Or using `docker`:
 
     docker pull ghcr.io/gofireflyio/aiac
 
+Or using `go install`:
+
+    go install github.com/gofireflyio/aiac/v2
+
 Alternatively, clone the repository and build from source:
 
     git clone https://github.com/gofireflyio/aiac.git
     go build
-
 
 ### Instructions
 
@@ -80,15 +96,16 @@ Alternatively, clone the repository and build from source:
 1. Click “Create new secret key” and copy it.
 1. Provide the API key via the `OPENAI_API_KEY` environment variable or via the `--api-key` command line flag.
 
-By default, aiac prints the extracted code to standard output and asks if it should save or re-generate the code 
+By default, aiac prints the extracted code to standard output and asks if it
+should save or regenerate the code:
 
     aiac get terraform for AWS EC2
 
 To store the resulting code to a file:
 
     aiac -o aws_ec2.tf get terraform for AWS EC2
-         
-To run using `docker`
+
+To run using `docker`:
 
     docker run \
     -it \
@@ -96,6 +113,7 @@ To run using `docker`
     ghcr.io/gofireflyio/aiac get terraform for ec2
 
 ## Example Output
+
 Command line prompt:
 
     aiac get dockerfile for nodejs with comments

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,17 @@
-module github.com/gofireflyio/aiac
+module github.com/gofireflyio/aiac/v2
 
 go 1.19
 
 require (
-	github.com/adrg/xdg v0.4.0
 	github.com/alecthomas/kong v0.7.1
 	github.com/briandowns/spinner v1.19.0
-	github.com/google/uuid v1.1.2
+	github.com/fatih/color v1.7.0
 	github.com/ido50/requests v1.5.0
 	github.com/manifoldco/promptui v0.9.0
 )
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
-	github.com/fatih/color v1.7.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
-github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
 github.com/alecthomas/kong v0.7.1 h1:azoTh0IOfwlAX3qN9sHWTxACE2oV8Bg2gAwBsMwDQY4=
 github.com/alecthomas/kong v0.7.1/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
@@ -122,7 +120,6 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -316,7 +313,6 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/libaiac/libaiac.go
+++ b/libaiac/libaiac.go
@@ -1,109 +1,84 @@
 package libaiac
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"github.com/fatih/color"
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/adrg/xdg"
 	"github.com/briandowns/spinner"
-	"github.com/google/uuid"
+	"github.com/fatih/color"
 	"github.com/ido50/requests"
 	"github.com/manifoldco/promptui"
 )
 
-const (
-	ChatGPTHost           = "chat.openai.com"
-	DefaultUserAgent      = "Mozilla/5.0 (Windows NT 10.0; rv:107.0) Gecko/20100101 Firefox/107.0"
-	SessionTokenCookie    = "__Secure-next-auth.session-token"
-	CloudflareTokenCookie = "cf_clearance"
-	CloudflareBmCookie    = "__cf_bm"
-	CallbackURLCookie     = "__Secure-next-auth.callback-url"
-)
-
-var ErrNoCode = errors.New("no code generated")
-
+// Client is a structure used to continuously generate IaC code via OpenAPI/ChatGPT
 type Client struct {
 	*requests.HTTPClient
-	token               string
-	cloudflareClearance string
-	cloudflareBm        string
-	userAgent           string
-	chatGPT             bool
+	apiKey string
 }
 
-type AIACClientInput struct {
-	ChatGPT             bool
-	Token               string
-	CloudflareClearance string
-	CloudflareBm        string
-	UserAgent           string
-}
+// NewClient creates a new instance of the Client struct, with the provided
+// input options. Neither the OpenAI API nor ChatGPT are yet contacted at this
+// point.
+func NewClient(apiKey string) *Client {
+	if apiKey == "" {
+		return nil
+	}
 
-func NewClient(input *AIACClientInput) *Client {
 	cli := &Client{
-		token:               input.Token,
-		chatGPT:             input.ChatGPT,
-		cloudflareClearance: input.CloudflareClearance,
-		cloudflareBm:        input.CloudflareBm,
-		userAgent:           input.UserAgent,
+		apiKey: strings.TrimPrefix(apiKey, "Bearer "),
 	}
 
-	if !cli.chatGPT {
-		cli.HTTPClient = requests.NewClient("https://api.openai.com/v1").
-			Accept("application/json").
-			Header("Authorization", fmt.Sprintf("Bearer %s", cli.token)).
-			ErrorHandler(func(
-				httpStatus int,
-				contentType string,
-				body io.Reader,
-			) error {
-				var res struct {
-					Error struct {
-						Message string `json:"message"`
-						Type    string `json:"type"`
-					} `json:"error"`
-				}
-				err := json.NewDecoder(body).Decode(&res)
-				if err != nil {
-					return fmt.Errorf(
-						"OpenAI returned response %s",
-						http.StatusText(httpStatus),
-					)
-				}
+	cli.HTTPClient = requests.NewClient("https://api.openai.com/v1").
+		Accept("application/json").
+		Header("Authorization", fmt.Sprintf("Bearer %s", cli.apiKey)).
+		ErrorHandler(func(
+			httpStatus int,
+			contentType string,
+			body io.Reader,
+		) error {
+			var res struct {
+				Error struct {
+					Message string `json:"message"`
+					Type    string `json:"type"`
+				} `json:"error"`
+			}
 
-				return fmt.Errorf("[%s] %s", res.Error.Type, res.Error.Message)
-			})
-	} else {
-		ua := cli.userAgent
-		if len(ua) == 0 {
-			ua = DefaultUserAgent
-		}
-		cli.HTTPClient = requests.NewClient(fmt.Sprintf("https://%s", ChatGPTHost)).
-			Header("User-Agent", ua).
-			Header("Accept-Language", "en-US,en;q=0.9")
-	}
+			err := json.NewDecoder(body).Decode(&res)
+			if err != nil {
+				return fmt.Errorf(
+					"OpenAI returned response %s",
+					http.StatusText(httpStatus),
+				)
+			}
+
+			return fmt.Errorf("[%s] %s", res.Error.Type, res.Error.Message)
+		})
 
 	return cli
 }
 
+// Ask asks the OpenAI API to generate code based on the provided prompt.
+// It is only meant to be used in command line applications (see GenerateCode
+// for library usage). The generated code will always be printed to standard
+// output, but may optionally be stored in the file whose path is provided by
+// the outputPath argument. To only print to standard output, provide an empty
+// string or a dash ("-") via outputPath. If shouldRetry is true, you will be
+// prompted whether to regenerate the response after it is printed to standard output,
+// in case you are unhappy with the response. If shouldQuit is true, the code
+// is printed to standard output and the function returns, without storing to a
+// file or asking whether to regenerate the response.
 func (client *Client) Ask(
 	ctx context.Context,
 	prompt string,
 	shouldRetry bool,
 	shouldQuit bool,
 	outputPath string,
-	readmePath string,
 ) (err error) {
 	spin := spinner.New(spinner.CharSets[2],
 		100*time.Millisecond,
@@ -118,27 +93,20 @@ func (client *Client) Ask(
 		}
 	}()
 
-	var code, readme string
-
-	if client.chatGPT {
-		code, readme, err = client.askViaChatGPT(ctx, prompt)
-	} else {
-		code, err = client.askViaAPI(ctx, prompt)
-	}
-
+	code, err := client.GenerateCode(ctx, prompt)
 	if err != nil {
 		return err
 	}
 
-	code = fmt.Sprintf("%s\n", code)
-
 	spin.Stop()
 	killed = true
 
-	fmt.Fprintf(os.Stdout, code)
+	fmt.Fprintln(os.Stdout, code)
+
 	if shouldQuit {
 		return nil
 	}
+
 	if shouldRetry {
 		input := promptui.Prompt{
 			Label: "Hit [S/s] to save the file or [R/r] to retry [Q/q] to quit",
@@ -157,11 +125,11 @@ func (client *Client) Ask(
 			return nil
 		} else if err != nil || strings.ToLower(result) == "r" {
 			// retry once more
-			return client.Ask(ctx, prompt, shouldRetry, shouldQuit, outputPath, readmePath)
+			return client.Ask(ctx, prompt, shouldRetry, shouldQuit, outputPath)
 		}
 	}
 
-	if outputPath == "-" {
+	if outputPath == "" {
 		input := promptui.Prompt{
 			Label: "Enter a file path",
 		}
@@ -172,179 +140,28 @@ func (client *Client) Ask(
 		}
 	}
 
-	f, err := os.Create(outputPath)
-	if err != nil {
-		return fmt.Errorf(
-			"failed creating output file %s: %w",
-			outputPath, err,
-		)
-	}
-
-	defer f.Close()
-
-	fmt.Fprint(f, code)
-
-	if readmePath != "" {
-		f, err := os.Create(readmePath)
+	if outputPath != "-" {
+		f, err := os.Create(outputPath)
 		if err != nil {
 			return fmt.Errorf(
-				"failed creating readme file %s: %w",
-				readmePath, err,
+				"failed creating output file %s: %w",
+				outputPath, err,
 			)
 		}
 
 		defer f.Close()
 
-		fmt.Fprintf(f, readme)
-	}
+		fmt.Fprintln(f, code)
 
-	if outputPath != "-" {
-		fmt.Printf("Code saved successfully at %s\n", outputPath)
+		fmt.Fprintf(os.Stderr, "Code saved successfully at %s\n", outputPath)
 	}
 
 	return nil
 }
 
-func (client *Client) askViaChatGPT(ctx context.Context, prompt string) (
-	code string,
-	readme string,
-	err error,
-) {
-	requestID, err := uuid.NewRandom()
-	if err != nil {
-		return code, readme, fmt.Errorf("failed generating UUID: %w", err)
-	}
-
-	accessToken, err := client.loadAccessToken(ctx)
-	if err != nil {
-		return code, readme, fmt.Errorf("failed loading access token: %w", err)
-	}
-
-	cacheAccessToken(accessToken)
-
-	// start a conversation
-	body := map[string]interface{}{
-		"action": "next",
-		"messages": []map[string]interface{}{
-			{
-				"id":   requestID.String(),
-				"role": "user",
-				"content": map[string]interface{}{
-					"content_type": "text",
-					"parts":        []string{prompt},
-				},
-			},
-		},
-		"model":           "text-davinci-002-render",
-		"conversation_id": nil,
-	}
-
-	parentID, err := uuid.NewRandom()
-	if err != nil {
-		return code, readme, fmt.Errorf(
-			"failed generating initial parent ID: %w",
-			err,
-		)
-	}
-
-	body["parent_message_id"] = parentID.String()
-
-	messages := make(chan []byte)
-
-	err = client.NewRequest("POST", "/backend-api/conversation").
-		Accept("text/event-stream").
-		JSONBody(body).
-		Header("Authorization", fmt.Sprintf("Bearer %s", accessToken)).
-		Cookie(&http.Cookie{
-			Name:   CallbackURLCookie,
-			Value:  "https://" + ChatGPTHost + "/",
-			Path:   "/",
-			Domain: ChatGPTHost,
-		}).
-		Cookie(&http.Cookie{
-			Name:   SessionTokenCookie,
-			Value:  client.token,
-			Path:   "/",
-			Domain: ChatGPTHost,
-		}).
-		Cookie(&http.Cookie{
-			Name:   CloudflareTokenCookie,
-			Value:  client.cloudflareClearance,
-			Path:   "/",
-			Domain: ChatGPTHost,
-		}).
-		Cookie(&http.Cookie{
-			Name:   CloudflareBmCookie,
-			Value:  client.cloudflareBm,
-			Path:   "/",
-			Domain: ChatGPTHost,
-		}).
-		Subscribe(ctx, messages)
-	if err != nil {
-		return code, readme, fmt.Errorf("failed starting a conversation: %w", err)
-	}
-
-	type ChatGPTMessage struct {
-		Message struct {
-			ID      string `json:"id"`
-			Content struct {
-				ContentType string   `json:"content_type"`
-				Parts       []string `json:"parts"`
-			} `json:"content"`
-		} `json:"message"`
-		ConversationID string  `json:"conversation_id"`
-		Error          *string `json:"error"`
-	}
-
-	var finalMessage string
-
-	for bmsg := range messages {
-		bmsg = bytes.TrimSpace(bytes.TrimPrefix(bmsg, []byte("data: ")))
-
-		if bytes.Compare(bmsg, []byte{'[', 'D', 'O', 'N', 'E', ']'}) == 0 {
-			break
-		}
-
-		var msg ChatGPTMessage
-		err = json.Unmarshal(bmsg, &msg)
-		if err != nil {
-			return code, readme, fmt.Errorf(
-				"failed parsing ChatGPT response: %w",
-				err,
-			)
-		}
-
-		if len(msg.Message.Content.Parts) < 1 {
-			continue
-		}
-
-		finalMessage = msg.Message.Content.Parts[0]
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(finalMessage))
-
-	var writeOutput, alreadyHadCode bool
-	var b strings.Builder
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if line == "```" {
-			if !alreadyHadCode {
-				writeOutput = !writeOutput
-				if !writeOutput {
-					alreadyHadCode = true
-				}
-			}
-		} else if writeOutput {
-			fmt.Fprintln(&b, line)
-		}
-	}
-
-	return b.String(), finalMessage, nil
-}
-
-func (client *Client) askViaAPI(ctx context.Context, prompt string) (
+// GenerateCode sends the provided prompt to the OpenAI API and returns the
+// generated code.
+func (client *Client) GenerateCode(ctx context.Context, prompt string) (
 	code string,
 	err error,
 ) {
@@ -382,78 +199,4 @@ func (client *Client) askViaAPI(ctx context.Context, prompt string) (
 	}
 
 	return strings.TrimSpace(answer.Choices[0].Text), nil
-}
-
-type CacheFile struct {
-	AccessToken string `json:"accessToken"`
-	Expiry      int64  `json:"expiry"`
-}
-
-func (client *Client) loadAccessToken(ctx context.Context) (token string, err error) {
-	// try to load access token from cache file
-	f, err := os.Open(filepath.Join(xdg.ConfigHome, "aiac.token"))
-	if err == nil {
-		defer f.Close()
-
-		var tokenData CacheFile
-		err = json.NewDecoder(f).Decode(&tokenData)
-		if err == nil && time.Now().Unix() < tokenData.Expiry {
-			// cached token has not expired yet
-			return tokenData.AccessToken, nil
-		}
-	}
-
-	// get an access token from ChatGPT
-	var session struct {
-		AccessToken string `json:"accessToken"`
-	}
-
-	err = client.NewRequest("GET", "/api/auth/session").
-		Cookie(&http.Cookie{
-			Name:   SessionTokenCookie,
-			Value:  client.token,
-			Path:   "/",
-			Domain: ChatGPTHost,
-		}).
-		Cookie(&http.Cookie{
-			Name:   CloudflareTokenCookie,
-			Value:  client.cloudflareClearance,
-			Path:   "/",
-			Domain: ChatGPTHost,
-		}).
-		Cookie(&http.Cookie{
-			Name:   CloudflareBmCookie,
-			Value:  client.cloudflareBm,
-			Path:   "/",
-			Domain: ChatGPTHost,
-		}).
-		Into(&session).
-		RunContext(ctx)
-	if err != nil {
-		return token, fmt.Errorf(
-			"failed getting session details: %w",
-			err,
-		)
-	}
-
-	return session.AccessToken, nil
-}
-
-func cacheAccessToken(token string) error {
-	f, err := os.Create(filepath.Join(xdg.ConfigHome, "aiac.token"))
-	if err != nil {
-		return fmt.Errorf("failed creating token file: %w", err)
-	}
-
-	defer f.Close()
-
-	err = json.NewEncoder(f).Encode(CacheFile{
-		AccessToken: token,
-		Expiry:      time.Now().Add(3600 * time.Second).Unix(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed encoding token data: %w", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
This commit performs the following backwards-incompatible modifications to the codebase:

- ChatGPT support is completely removed. Since this was particularly fragile, undocumented, and an unsupported use case (both from our part and from OpenAI's part), it is better removed until/if ChatGPT provides an API.

- The code is documented with GoDoc-compliant comments.

- The NewClient function no longer receives an input struct, but only receives the OpenAI API key.

- The `Ask` method no longer accepts a `readmePath` argument, as this only worked with ChatGPT. Documentation also makes it clear that this method is meant to be used in CLI programs only.

- The `askViaAPI` method is renamed `GenerateCode` and thus publically exposed, allowing real library usage of the module.

Due to these breaking changes, this commit should be released as part of version 2.0.0 of aiac:

    git tag v2.0.0
    git push origin v2.0.0
    go mod tidy
    go mod publish