### PR TITLE
Switch to ChatGPT API by default, allow other models

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,9 @@ linters:
     - promlinter
     - testpackage
     - varnamelen
+    - nonamedreturns
+    - tagliatelle
+    - exhaustruct
 issues:
   new: true
   new-from-rev: HEAD

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Generator.
 * [Instructions](#instructions)
     * [Installation](#installation)
     * [Usage](#usage)
+    * [Choosing a Different Model](#choosing-a-different-model)
 * [Example Output](#example-output)
 * [Troubleshooting](#troubleshooting)
 * [Support Channels](#support-channels)
@@ -33,7 +34,8 @@ Generator.
 via [OpenAI](https://openai.com/)'s API. The CLI allows you to ask the model to generate templates
 for different scenarios (e.g. "get terraform for AWS EC2"). It will make the
 request, and store the resulting code to a file, or simply print it to standard
-output.
+output. By default, `aiac` uses the same model used by ChatGPT, but allows using
+different models.
 
 ## Use Cases and Example Prompts
 
@@ -101,12 +103,12 @@ Alternatively, clone the repository and build from source:
 
 ### Usage
 
-1. Create your OpenAI API key [here](https://beta.openai.com/account/api-keys).
+1. Create your OpenAI API key [here](platform.openai.com/account/api-keys).
 2. Click “Create new secret key” and copy it.
 3. Provide the API key via the `OPENAI_API_KEY` environment variable or via the `--api-key` command line flag.
 
 By default, aiac prints the extracted code to standard output and asks if it
-should save or regenerate the code:
+should save the code, regenerate it, or modify the prompt:
 
     aiac get terraform for AWS EC2
 
@@ -120,6 +122,15 @@ To run using `docker`:
     -it \
     -e OPENAI_API_KEY=[PUT YOUR KEY HERE] \
     ghcr.io/gofireflyio/aiac get terraform for ec2
+
+If you want to receive and/or store the complete Markdown output from OpenAI,
+including explanations (if any), use the `--full` flag.
+
+### Choosing a Different Model
+
+Use the `--model` flag to select a different model than the default (currently
+"gpt-3.5-turbo"). Not all OpenAI models are supported, use `aiac list-models`
+to get a list of all supported models.
 
 ## Example Output
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Using `docker`:
 
 Using `go install`:
 
-    go install github.com/gofireflyio/aiac/v2
+    go install github.com/gofireflyio/aiac/v2@latest
 
 Alternatively, clone the repository and build from source:
 

--- a/main.go
+++ b/main.go
@@ -11,35 +11,70 @@ import (
 )
 
 type flags struct {
-	APIKey     string `help:"OpenAI API key" required:"" env:"OPENAI_API_KEY"`
-	OutputFile string `help:"Output file to push resulting code to, defaults to stdout" default:"-" type:"path" short:"o"`
-	Save       bool   `help:"Save AIaC response without retry prompt" default:false short:"s"`
-	Quiet      bool   `help:"Print AIaC response to stdout and exit (non-interactive mode)" default:false short:"q"`
+	APIKey     string   `help:"OpenAI API key" required:"" env:"OPENAI_API_KEY"`
+	ListModels struct{} `cmd:"" help:"List supported models"`
+	OutputFile string   `help:"Output file to push resulting code to, defaults to stdout" default:"-" type:"path" short:"o"` //nolint: lll
+	Quiet      bool     `help:"Print AIaC response to stdout and exit (non-interactive mode)" default:"false" short:"q"`
+	Save       bool     `help:"Save AIaC response without retry prompt" default:"false" short:"s"`
 	Get        struct {
-		What []string `arg:"" help:"Which IaC template to generate"`
+		Full  bool          `help:"Return full output, including explanations, if any" default:"false" short:"f"`
+		Model libaiac.Model `help:"Model to use"`
+		What  []string      `arg:"" help:"Which IaC template to generate"`
 	} `cmd:"" help:"Generate IaC code" aliases:"generate"`
 }
 
 func main() {
-	if len(os.Args) < 2 {
+	if len(os.Args) < 2 { //nolint: gomnd
 		os.Args = append(os.Args, "--help")
 	}
-	var cli flags
-	cmd := kong.Parse(&cli)
 
-	if cmd.Command() != "get <what>" {
+	var cli flags
+	parser := kong.Must(
+		&cli,
+		kong.Name("aiac"),
+		kong.Description("Artificial Intelligence Infrastructure-as-Code Generator."),
+	)
+
+	ctx, err := parser.Parse(os.Args[1:])
+	if err != nil {
+		if err.Error() == "missing flags: --api-key=STRING" {
+			fmt.Fprintln(os.Stderr, `You must provide an OpenAI API key via the --api-key flag, or
+the OPENAI_API_KEY environment variable.
+
+Get your API key from https://platform.openai.com/account/api-keys.`)
+		} else {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		}
+
+		os.Exit(1)
+	}
+
+	if ctx.Command() == "list-models" {
+		for _, model := range libaiac.SupportedModels {
+			fmt.Println(model)
+		}
+
+		os.Exit(0)
+	}
+
+	if ctx.Command() != "get <what>" {
 		fmt.Fprintln(os.Stderr, "Unknown command")
 		os.Exit(1)
 	}
 
-	client := libaiac.NewClient(cli.APIKey)
+	client := libaiac.NewClient(cli.APIKey).
+		SetFull(cli.Get.Full)
 
-	err := client.Ask(
+	if cli.Get.Model != "" {
+		client.SetModel(cli.Get.Model)
+	}
+
+	err = client.Ask(
 		context.TODO(),
 		// NOTE: we are prepending the word "generate" to the prompt, this
 		// ensures the language model actually generates code. The word "get",
 		// on the other hand, doesn't necessarily result in code being generated.
-		fmt.Sprintf("generate %s", strings.Join(cli.Get.What, " ")),
+		fmt.Sprintf("generate code for a %s", strings.Join(cli.Get.What, " ")),
 		!cli.Save,
 		cli.Quiet,
 		cli.OutputFile,

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ type flags struct {
 	Save       bool     `help:"Save AIaC response without retry prompt" default:"false" short:"s"`
 	Get        struct {
 		Full  bool          `help:"Return full output, including explanations, if any" default:"false" short:"f"`
-		Model libaiac.Model `help:"Model to use"`
+		Model libaiac.Model `help:"Model to use, default to \"gpt-3.5-turbo\""`
 		What  []string      `arg:"" help:"Which IaC template to generate"`
 	} `cmd:"" help:"Generate IaC code" aliases:"generate"`
 }


### PR DESCRIPTION
aiac will now use the ChatGPT API (and thus the gpt-3.5-turbo model) instead of the text-davinci-003 model by default. It also allows selecting the model to use, with the aforementioned two being supported, along with the code-davinci-002 model, which is specifically designed to generate code. A model can be selected via the `--model` flag, and a list of all supported models is available via the `list-models` command.

Since ChatGPT usually returns a Markdown-formatted description rather than just code, the library will extract the code from the response. A new flag, `--full`, is added to prevent that and echo or save the complete response from the API.

The command line prompt will now also allow users to modify the prompt after receiving a response (using the "m" key), along with the previous option to retry with the same prompt.

Also included are small fixes: entering Ctrl+D and Ctrl+C after receiving a response will quit the program as expected, rather than regenerate a response.