### PR TITLE
Add `-f` / `--full` cli flag to `get` command to allow printing full Markdown response to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ type flags struct {
 		OutputFile string        `help:"Output file to push resulting code to" optional:"" type:"path" short:"o"`         //nolint: lll
 		ReadmeFile string        `help:"Readme file to push entire Markdown output to" optional:"" type:"path" short:"r"` //nolint: lll
 		Quiet      bool          `help:"Non-interactive mode, print/save output and exit" default:"false" short:"q"`      //nolint: lll
+		Full       bool          `help:"Print full Markdown output to stdout" default:"false" short:"f"`                  //nolint: lll
 		Model      libaiac.Model `help:"Model to use, default to \"gpt-3.5-turbo\""`
 		What       []string      `arg:"" help:"Which IaC template to generate"`
 	} `cmd:"" help:"Generate IaC code" aliases:"generate"`
@@ -161,7 +162,12 @@ ATTEMPTS:
 		} else {
 			spin.Stop()
 
-			fmt.Fprintln(os.Stdout, res.Code)
+			stdoutOutput := res.Code
+			if cli.Get.Full {
+				stdoutOutput = res.FullOutput
+			}
+
+			fmt.Fprintln(os.Stdout, stdoutOutput)
 
 			if cli.Get.Quiet {
 				break ATTEMPTS


### PR DESCRIPTION
# what
Add `-f` / `--full` cli flag for `get` command to allow printing full Markdown response to stdout

# why 
Was mentioned by @ido50 https://github.com/gofireflyio/aiac/pull/24#issuecomment-1458066106 that the option to print out full Markdown to stdout will be available. But it didnt get to 2.2 release.
It is definitely useful to get the explanations sometimes. Explanations for code, or for answer on prompts that are not even code related. (Yeah i use aiac for all requests to openAI these days, a lot more convenient than other tools, I am sure I am not the only one ☺️ )

# considerations
What thinking should the `--output-file` or `--readme-file` behave differently if `--full` is provided, but it seems they should remain as they are.
Also potentially should print `Generating output` (or something like this) instead of `Generating code` when `--full` is passed?