### PR TITLE
Add support for GPT-4 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,14 @@ You can ask it to also store the code to a specific file with a flag:
 
     aiac get terraform for eks --output-file=eks.tf
 
-You can use a flag to save the complete Markdown output as well:
+You can use a flag to save the full Markdown output as well:
 
     aiac get terraform for eks --output-file=eks.tf --readme-file=eks.md
+
+If you prefer aiac to print the full Markdown output to standard output rather
+than the extracted code, use the `-f` or `--full` flag:
+
+    aiac get terraform for eks -f
 
 You can use aiac in non-interactive mode, simply printing the generated code
 to standard output, and optionally saving it to files with the above flags,
@@ -132,7 +137,7 @@ by providing the `-q` or `--quiet` flag:
     aiac get terraform for eks -q
 
 By default, aiac uses the gpt-3.5-turbo chat model, but other models are
-supported. You can list all supported models:
+supported, including gpt-4. You can list all supported models:
 
     aiac list-models
 

--- a/libaiac/models.go
+++ b/libaiac/models.go
@@ -54,6 +54,21 @@ var (
 	// snapshot of gpt-3.5-turbo
 	ModelGPT35Turbo0301 = Model{"gpt-3.5-turbo-0301", 4096, ModelTypeChat}
 
+	// ModelGPT4 represents the gpt-4 model
+	ModelGPT4 = Model{"gpt-4", 8192, ModelTypeChat}
+
+	// ModelGPT40314 represents the gpt-4-0314 model, a March 14th 2023 snapshot
+	// of the gpt-4 model.
+	ModelGPT40314 = Model{"gpt-4-0314", 8192, ModelTypeChat}
+
+	// ModelGPT432K represents the gpt-4-32k model, which is the same as gpt-4,
+	// but with 4x the context length.
+	ModelGPT432K = Model{"gpt-4-32k", 32768, ModelTypeChat}
+
+	// ModelGPT432K0314 represents the gpt-4-32k-0314 model, a March 14th 2023
+	// snapshot of the gpt-4-32k model
+	ModelGPT432K0314 = Model{"gpt-4-32k-0314", 32768, ModelTypeChat}
+
 	// ModelTextDaVinci3 represents the text-davinci-003 language generation
 	// model.
 	ModelTextDaVinci3 = Model{"text-davinci-003", 4097, ModelTypeCompletion}
@@ -66,6 +81,10 @@ var (
 	SupportedModels = []Model{
 		ModelGPT35Turbo,
 		ModelGPT35Turbo0301,
+		ModelGPT4,
+		ModelGPT40314,
+		ModelGPT432K,
+		ModelGPT432K0314,
 		ModelTextDaVinci3,
 		ModelTextDaVinci2,
 	}


### PR DESCRIPTION
This commit adds support for all models in the GPT-4 family. Theses are chat models similar to gpt-3.5-turbo, which remains the default model for now, as GPT-4 is still in limited beta.