### PR TITLE
 Add ability to save and continue chatting 

### DIFF
--- a/libaiac/openai/models.go
+++ b/libaiac/openai/models.go
@@ -27,14 +27,6 @@ var (
 	// snapshot of the gpt-4-32k model
 	ModelGPT432K0314 = types.Model{"gpt-4-32k-0314", 32768, types.ModelTypeChat}
 
-	// ModelTextDaVinci3 represents the text-davinci-003 language generation
-	// model.
-	ModelTextDaVinci3 = types.Model{"text-davinci-003", 4097, types.ModelTypeCompletion}
-
-	// ModelTextDaVinci2 represents the text-davinci-002 language generation
-	// model.
-	ModelTextDaVinci2 = types.Model{"text-davinci-002", 4097, types.ModelTypeCompletion}
-
 	// SupportedModels is a list of all language models supported by this
 	// backend implementation.
 	SupportedModels = []types.Model{
@@ -44,8 +36,6 @@ var (
 		ModelGPT40314,
 		ModelGPT432K,
 		ModelGPT432K0314,
-		ModelTextDaVinci3,
-		ModelTextDaVinci2,
 	}
 )
 

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func printModels(cli flags) {
 	case libaiac.BackendBedrock:
 		client = &bedrock.Client{}
 	default:
-		fmt.Fprintf(os.Stderr, "Unknown backend %s\n")
+		fmt.Fprintf(os.Stderr, "Unknown backend %s\n", cli.Backend)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
The aiac prompt line, after showing results from the LLM provider,
allows saving only once, as it exits immediately after saving. This
commit introduces the ability to save and continue chatting, thus
allowing users to save multiple files during a conversation with
the model.

For backwards compatibility purposes, the "s" key will still save
and exit, but the new "w" key can be used to save and continue
chatting.

This PR also removes the text-davinci-003 and text-davinci-002 models,
which are set to be shut down by OpenAI on January 4.

A small bug is also fixed in the CLI: when an unsupported/unknown
model was provided, the error message did not properly include the
name of the model provided.

Closes #81 