### PR TITLE
Add support for the Ollama backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Generator.
 ## Description
 
 `aiac` is a command line tool to generate IaC (Infrastructure as Code) templates,
-configurations, utilities, queries and more via [LLM](https://en.wikipedia.org/wiki/Large_language_model) providers such as [OpenAI](https://openai.com/)
-and [Amazon Bedrock](https://aws.amazon.com/bedrock/). The CLI allows you to ask a model to generate templates
+configurations, utilities, queries and more via [LLM](https://en.wikipedia.org/wiki/Large_language_model) providers such as [OpenAI](https://openai.com/),
+[Amazon Bedrock](https://aws.amazon.com/bedrock/) and [Ollama](https://ollama.ai/). The CLI allows you to ask a model to generate templates
 for different scenarios (e.g. "get terraform for AWS EC2"). It composes an
 appropriate request to the selected provider, and stores the resulting code to
 a file, and/or prints it to standard output.
@@ -90,6 +90,11 @@ For **Amazon Bedrock**, you will need an AWS account with Bedrock enabled, and
 access to relevant models (currently Amazon Titan and Anthropic Claude are
 supported by `aiac`). Refer to the [Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) for more information.
 
+For **Ollama**, you only need the URL to the local Ollama API server, including
+the /api path prefix. This defaults to http://localhost:11434/api. Ollama does
+not provide an authentication mechanism, but one may be in place in case of a
+proxy server being used. This scenario is not currently supported by `aiac`.
+
 ### Installation
 
 Via `brew`:
@@ -131,6 +136,12 @@ For **Amazon Bedrock**:
    environment variables, respectively, or via the `--aws-profile` and `--aws-region`
    command line flags. These values default to "default" and "us-east-1",
    respectively.
+
+For **Ollama**:
+
+1. Nothing needed except the URL to the API server, if the default one is not
+   used. Provide it via the `--ollama-url` flag or the `OLLAMA_API_URL`
+   environment variable. Don't forget to include the /api path prefix.
 
 #### Command Line
 
@@ -185,6 +196,12 @@ the AWS region and profile:
         --aws-region=us-east-1
 
 The default model when using Bedrock is "amazon.titan-text-lite-v1".
+
+To generate code via Ollama, provide the `--backend` flag:
+
+    aiac get terraform for eks --backend=ollama
+
+The default model when using Ollama is "codellama".
 
 #### Via Docker
 

--- a/libaiac/ollama/chat.go
+++ b/libaiac/ollama/chat.go
@@ -1,0 +1,87 @@
+package ollama
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gofireflyio/aiac/v4/libaiac/types"
+)
+
+// Conversation is a struct used to converse with an OpenAI chat model. It
+// maintains all messages sent/received in order to maintain context just like
+// using ChatGPT.
+type Conversation struct {
+	client   *Client
+	model    types.Model
+	messages []types.Message
+}
+
+type chatResponse struct {
+	Message types.Message `json:"message"`
+	Done    bool          `json:"done"`
+}
+
+// Chat initiates a conversation with an OpenAI chat model. A conversation
+// maintains context, allowing to send further instructions to modify the output
+// from previous requests, just like using the ChatGPT website.
+func (client *Client) Chat(model types.Model) types.Conversation {
+	if model.Type != types.ModelTypeChat {
+		return nil
+	}
+
+	return &Conversation{
+		client: client,
+		model:  model,
+	}
+}
+
+// Send sends the provided message to the API and returns a Response object.
+// To maintain context, all previous messages (whether from you to the API or
+// vice-versa) are sent as well, allowing you to ask the API to modify the
+// code it already generated.
+func (conv *Conversation) Send(ctx context.Context, prompt string, msgs ...types.Message) (
+	res types.Response,
+	err error,
+) {
+	var answer chatResponse
+
+	if len(msgs) > 0 {
+		conv.messages = append(conv.messages, msgs...)
+	}
+
+	conv.messages = append(conv.messages, types.Message{
+		Role:    "user",
+		Content: prompt,
+	})
+
+	err = conv.client.NewRequest("POST", "/chat").
+		JSONBody(map[string]interface{}{
+			"model":    conv.model.Name,
+			"messages": conv.messages,
+			"options": map[string]interface{}{
+				"temperature": 0.2,
+			},
+			"stream": false,
+		}).
+		Into(&answer).
+		RunContext(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed sending prompt: %w", err)
+	}
+
+	if !answer.Done {
+		return res, fmt.Errorf("%w: unexpected truncated response", types.ErrResultTruncated)
+	}
+
+	conv.messages = append(conv.messages, answer.Message)
+
+	res.FullOutput = strings.TrimSpace(answer.Message.Content)
+
+	var ok bool
+	if res.Code, ok = types.ExtractCode(res.FullOutput); !ok {
+		res.Code = res.FullOutput
+	}
+
+	return res, nil
+}

--- a/libaiac/ollama/client.go
+++ b/libaiac/ollama/client.go
@@ -1,0 +1,69 @@
+package ollama
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gofireflyio/aiac/v4/libaiac/types"
+	"github.com/ido50/requests"
+)
+
+// DefaultAPIURL is the default URL for a local Ollama API server
+const DefaultAPIURL = "http://localhost:11434/api"
+
+// Client is a structure used to continuously generate IaC code via Ollama
+type Client struct {
+	*requests.HTTPClient
+}
+
+// NewClientOptions is a struct containing all the parameters accepted by the
+// NewClient constructor.
+type NewClientOptions struct {
+	// URL is the URL of the API server (including the /api path prefix). Defaults to DefaultAPIURL.
+	URL string
+}
+
+// NewClient creates a new instance of the Client struct, with the provided
+// input options. The Ollama API server is not contacted at this point.
+func NewClient(opts *NewClientOptions) *Client {
+	if opts == nil {
+		opts = &NewClientOptions{}
+	}
+
+	if opts.URL == "" {
+		opts.URL = DefaultAPIURL
+	}
+
+	cli := &Client{}
+
+	cli.HTTPClient = requests.NewClient(opts.URL).
+		Accept("application/json").
+		ErrorHandler(func(
+			httpStatus int,
+			contentType string,
+			body io.Reader,
+		) error {
+			var res struct {
+				Error string `json:"error"`
+			}
+
+			err := json.NewDecoder(body).Decode(&res)
+			if err != nil {
+				return fmt.Errorf(
+					"%w %s",
+					types.ErrUnexpectedStatus,
+					http.StatusText(httpStatus),
+				)
+			}
+
+			return fmt.Errorf(
+				"%w:  %s",
+				types.ErrRequestFailed,
+				res.Error,
+			)
+		})
+
+	return cli
+}

--- a/libaiac/ollama/completion.go
+++ b/libaiac/ollama/completion.go
@@ -1,0 +1,52 @@
+package ollama
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gofireflyio/aiac/v4/libaiac/types"
+)
+
+type completionResponse struct {
+	Response string `json:"response"`
+	Done     bool   `json:"done"`
+}
+
+// Complete sends a request to OpenAI's Completions API using the provided model
+// and prompt, and returns the response
+func (client *Client) Complete(
+	ctx context.Context,
+	model types.Model,
+	prompt string,
+) (res types.Response, err error) {
+	var answer completionResponse
+
+	err = client.NewRequest("POST", "/generate").
+		JSONBody(map[string]interface{}{
+			"model":  model.Name,
+			"prompt": prompt,
+			"options": map[string]interface{}{
+				"temperature": 0.2,
+			},
+			"stream": false,
+		}).
+		Into(&answer).
+		RunContext(ctx)
+	if err != nil {
+		return res, fmt.Errorf("failed sending prompt: %w", err)
+	}
+
+	if !answer.Done {
+		return res, fmt.Errorf("%w: unexpected truncated response", types.ErrResultTruncated)
+	}
+
+	res.FullOutput = strings.TrimSpace(answer.Response)
+
+	var ok bool
+	if res.Code, ok = types.ExtractCode(res.FullOutput); !ok {
+		res.Code = res.FullOutput
+	}
+
+	return res, nil
+}

--- a/libaiac/ollama/models.go
+++ b/libaiac/ollama/models.go
@@ -1,0 +1,63 @@
+package ollama
+
+import (
+	"github.com/gofireflyio/aiac/v4/libaiac/types"
+)
+
+var (
+	// ModelCodeLlama represents the codellama model
+	ModelCodeLlama = types.Model{"codellama", 0, types.ModelTypeChat}
+
+	// ModelDeepseekCoder represents the deepseek-coder model
+	ModelDeepseekCoder = types.Model{"deepseek-coder", 0, types.ModelTypeChat}
+
+	// ModelWizardCoder represents the wizard-coder model
+	ModelWizardCoder = types.Model{"wizard-coder", 0, types.ModelTypeChat}
+
+	// ModelPhindCodeLlama represents the phind-codellama model
+	ModelPhindCodeLlama = types.Model{"phind-codellama", 0, types.ModelTypeChat}
+
+	// ModeCodeUp represents the codeup model
+	ModelCodeUp = types.Model{"codeup", 0, types.ModelTypeChat}
+
+	// ModeStarCoder represents the starcoder model
+	ModelStarCoder = types.Model{"starcoder", 0, types.ModelTypeChat}
+
+	// ModelSQLCoder represents the sqlcoder model
+	ModelSQLCoder = types.Model{"sqlcoder", 0, types.ModelTypeChat}
+
+	// ModelStableCode represents the stablecode model
+	ModelStableCode = types.Model{"stablecode", 0, types.ModelTypeChat}
+
+	// ModelMagicoder represents the magicoder model
+	ModelMagicoder = types.Model{"magicoder", 0, types.ModelTypeChat}
+
+	// ModelCodeBooga represents the codebooga model
+	ModelCodeBooga = types.Model{"codebooga", 0, types.ModelTypeChat}
+
+	// SupportedModels is a list of all language models supported by this
+	// backend implementation.
+	SupportedModels = []types.Model{
+		ModelCodeLlama,
+		ModelDeepseekCoder,
+		ModelWizardCoder,
+		ModelPhindCodeLlama,
+		ModelCodeUp,
+		ModelStarCoder,
+		ModelSQLCoder,
+		ModelStableCode,
+		ModelMagicoder,
+		ModelCodeBooga,
+	}
+)
+
+// ListModels returns a list of all the models supported by this backend
+// implementation.
+func (client *Client) ListModels() []types.Model {
+	return SupportedModels
+}
+
+// DefaultModel returns the default model used by this backend.
+func (client *Client) DefaultModel() types.Model {
+	return ModelCodeLlama
+}

--- a/libaiac/openai/client.go
+++ b/libaiac/openai/client.go
@@ -14,7 +14,7 @@ import (
 // OpenAIBackend is the default URI endpoint for the OpenAI API.
 const OpenAIBackend = "https://api.openai.com/v1"
 
-// Client is a structure used to continuously generate IaC code via OpenAPI/ChatGPT
+// Client is a structure used to continuously generate IaC code via OpenAPI
 type Client struct {
 	*requests.HTTPClient
 	apiKey     string
@@ -27,16 +27,15 @@ type NewClientOptions struct {
 	// APIKey is the OpenAI API key to use for requests. This is required.
 	ApiKey string
 
-	// ChatGPTURL is the URL to use for ChatGPT requests. This is optional nd by default to openai backend.
+	// URL is the OpenAI API URL to userequests. Optional, defaults to OpenAIBackend.
 	URL string
 
-	// APIVersion is the version of the OpenAI API to use. This is optional and by default to non specified.
+	// APIVersion is the version of the OpenAI API to use. Optional.
 	APIVersion string
 }
 
 // NewClient creates a new instance of the Client struct, with the provided
-// input options. Neither the OpenAI API nor ChatGPT are yet contacted at this
-// point.
+// input options. The OpenAI API backend is not yet contacted at this point.
 func NewClient(opts *NewClientOptions) *Client {
 	if opts == nil {
 		return nil

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/gofireflyio/aiac/v4/libaiac"
 	"github.com/gofireflyio/aiac/v4/libaiac/bedrock"
+	"github.com/gofireflyio/aiac/v4/libaiac/ollama"
 	"github.com/gofireflyio/aiac/v4/libaiac/openai"
 	"github.com/gofireflyio/aiac/v4/libaiac/types"
 	"github.com/manifoldco/promptui"
@@ -22,7 +23,7 @@ import (
 )
 
 type flags struct {
-	Backend    libaiac.BackendName `help:"Backend to use (openai, bedrock)" enum:"openai,bedrock" default:"openai" short:"b" env:"AIAC_BACKEND"`
+	Backend    libaiac.BackendName `help:"Backend to use (openai, bedrock, ollama)" enum:"openai,bedrock,ollama" default:"openai" short:"b" env:"AIAC_BACKEND"`
 	ListModels struct {
 		Type types.ModelType `arg:"" help:"List models of specific type" optional:""`
 	} `cmd:"" help:"List supported models"`
@@ -35,6 +36,9 @@ type flags struct {
 		// Amazon Bedrock flags
 		AWSProfile string `help:"AWS profile" default:"default" env:"AWS_PROFILE"`
 		AWSRegion  string `help:"AWS region" default:"us-east-1" env:"AWS_REGION"`
+
+		// Ollama flags
+		OllamaURL string `help:"Ollama API URL, including /api path prefix" default:"http://localhost:11434/api" env:"OLLAMA_API_URL"`
 
 		// Generic Flags
 		OutputFile string   `help:"Output file to push resulting code to" optional:"" type:"path" short:"o"`         //nolint: lll
@@ -103,6 +107,8 @@ func printModels(cli flags) {
 		client = &openai.Client{}
 	case libaiac.BackendBedrock:
 		client = &bedrock.Client{}
+	case libaiac.BackendOllama:
+		client = &ollama.Client{}
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown backend %s\n", cli.Backend)
 		os.Exit(1)
@@ -135,6 +141,7 @@ from https://platform.openai.com/account/api-keys.`)
 		APIVersion: cli.Get.APIVersion,
 		AWSProfile: cli.Get.AWSProfile,
 		AWSRegion:  cli.Get.AWSRegion,
+		OllamaURL:  cli.Get.OllamaURL,
 	})
 
 	var model types.Model


### PR DESCRIPTION
This commit introduces support for the ollama.ai backend. Ollama is an open source LLAMA backend meant for local usage. It supports many different models, many of them related to code generation.

Usage of the ollama backend is available via the `--backend` flag or `AIAC_BACKEND` environment variables set to `"ollama"`. Ollama doesn't support authentication currently, so the only related flag is `--ollama-url` for the API server's URL, but if not used, the default URL is used (http://localhost:11434/api). With this commit, `aiac` will not yet support a scenario where the API server is running behind an authenticating proxy.

Resolves: #77