### PR TITLE
Enabling Config Values to Use ENV Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ default_backend = "official_openai"   # Default backend when one is not selected
 [backends.official_openai]
 type = "openai"
 api_key = "API KEY"
+# Or 
+# api_key = "$OPENAI_API_KEY"
 default_model = "gpt-4o"              # Default model to use for this backend
 
 [backends.azure_openai]

--- a/libaiac/config.go
+++ b/libaiac/config.go
@@ -102,6 +102,22 @@ func replaceEnvVars(conf Config) Config {
 			backendConfig.AWSProfile = replaceEnvVar(backendConfig.AWSProfile)
 		}
 
+		if backendConfig.AWSRegion != "" {
+			backendConfig.AWSRegion = replaceEnvVar(backendConfig.AWSRegion)
+		}
+
+		if backendConfig.URL != "" {
+			backendConfig.URL = replaceEnvVar(backendConfig.URL)
+		}
+
+		if backendConfig.DefaultModel != "" {
+			backendConfig.DefaultModel = replaceEnvVar(backendConfig.DefaultModel)
+		}
+
+		if backendConfig.APIVersion != "" {
+			backendConfig.APIVersion = replaceEnvVar(backendConfig.APIVersion)
+		}
+
 		conf.Backends[backendName] = backendConfig
 	}
 


### PR DESCRIPTION
This Pull-Request enables the config files to have variables as "$OPENAI_API_KEY" in place of the actual value.
This is needed not to share sensetive data in dotfiles over source control (git).
